### PR TITLE
Security improvement - adding type=password for priv key

### DIFF
--- a/src/components/UploadFiles.vue
+++ b/src/components/UploadFiles.vue
@@ -19,7 +19,7 @@
         <v-row justify="center" align="center">
           <v-col cols="8">
             <v-text-field
-              label="Etho Protocol Key"	type="password"
+              label="ETHO Pritvate Key"	type="password"
               @change="setKey"
             ></v-text-field>
           </v-col>
@@ -52,7 +52,7 @@
         <v-row justify="center" align="center">
           <v-col cols="8">
             <v-text-field
-              label="Etho Protocol Key"	type="password"
+              label="ETHO Private Key"	type="password"
               @change="setKey"
             ></v-text-field>
           </v-col>

--- a/src/components/UploadFiles.vue
+++ b/src/components/UploadFiles.vue
@@ -19,7 +19,7 @@
         <v-row justify="center" align="center">
           <v-col cols="8">
             <v-text-field
-              label="Etho Protocol Key"
+              label="Etho Protocol Key"	type="password"
               @change="setKey"
             ></v-text-field>
           </v-col>
@@ -52,7 +52,7 @@
         <v-row justify="center" align="center">
           <v-col cols="8">
             <v-text-field
-              label="Etho Protocol Key"
+              label="Etho Protocol Key"	type="password"
               @change="setKey"
             ></v-text-field>
           </v-col>


### PR DESCRIPTION
hides private key so browser doesn't remember it + if tutorial video's get made, you don't have to worry that users see your key.